### PR TITLE
fix(catchup): anchor to last weekday, remove lastFetchedAt, separate …

### DIFF
--- a/api/standup.ts
+++ b/api/standup.ts
@@ -39,9 +39,9 @@ Here are their time log entries grouped by date:
 
 ${entriesText}
 
-Summarize in 2-3 groups max. Short past-tense bullets, 1 line each, max 3 bullets per group.
-Group by project or theme across dates.
-If there are entries for today (${today}), put them in a final "Today" group (present tense).
+Summarize weekday entries in 2-3 groups max, grouped by project or theme across dates. Short past-tense bullets, 1 line each, max 3 bullets per group.
+If there are Saturday or Sunday entries, collect all weekend work into a single "## Weekend" group placed after the weekday groups.
+If there are entries for today (${today}), put them in a final "## Today" group (present tense).
 No intro or outro. Return only markdown using: ## Group Name, then - bullet.`;
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -73,7 +73,7 @@ const showReleaseNotification = () => {
       kind: 'info',
       title: 'New Update',
       message: __COMMIT_MESSAGE__,
-      autoDismissMs: 10000,
+      autoDismissMs: 5000,
       expandOnEnqueue: true,
     });
     lastSeenVersion.value = __APP_VERSION__;

--- a/src/common/storageKeys.ts
+++ b/src/common/storageKeys.ts
@@ -23,7 +23,6 @@ export const storageKeys = {
   catchUp: {
     summary: (date: string) => `catchUpSummary-${date}`,
     dismissedDate: 'catchUpDismissedDate',
-    lastFetchedAt: 'catchUpLastFetchedAt',
   },
   notifications: {
     greetingFirstSeenAt: 'notificationGreetingFirstSeenAt',

--- a/src/composables/useCatchUpSummary.ts
+++ b/src/composables/useCatchUpSummary.ts
@@ -48,30 +48,7 @@ function readLogs(monthKey: string): TimeLog[] {
   }
 }
 
-function getLogsForSummary(): TimeLog[] {
-  const today = dayjs().startOf('day');
-  const lastFetchedAt = localStorage.getItem(storageKeys.catchUp.lastFetchedAt);
-
-  let fromDate: dayjs.Dayjs | null = null;
-
-  if (lastFetchedAt) {
-    fromDate = dayjs(lastFetchedAt).startOf('day');
-  } else {
-    // Scan backwards up to 14 days for the most recent day with logs.
-    for (let i = 1; i <= 14; i++) {
-      const d = dayjs().subtract(i, 'day').startOf('day');
-      const monthKey = `timeLogs-${d.format(yearAndMonthFormat)}`;
-      const logs = readLogs(monthKey);
-      if (logs.some((log) => parseLogDate(log.date)?.isSame(d, 'day'))) {
-        fromDate = d;
-        break;
-      }
-    }
-  }
-
-  if (!fromDate?.isValid()) return [];
-
-  const rangeStart = fromDate;
+function collectLogsFromDate(rangeStart: dayjs.Dayjs, today: dayjs.Dayjs): TimeLog[] {
   const allLogs: TimeLog[] = [];
   let cursor = rangeStart.startOf('month');
   const endMonth = today.startOf('month');
@@ -90,6 +67,31 @@ function getLogsForSummary(): TimeLog[] {
   }
 
   return allLogs;
+}
+
+function getLogsForSummary(): TimeLog[] {
+  const today = dayjs().startOf('day');
+
+  // Scan all stored log months newest-first. Find the latest weekday before today
+  // that has entries — that becomes the standup anchor. collectLogsFromDate then
+  // sweeps from that anchor to today, naturally picking up any weekend work in between.
+  const logMonthKeys = Object.keys(localStorage)
+    .filter((key) => /^timeLogs-\d{4}-\d{2}$/.test(key))
+    .sort()
+    .reverse();
+
+  for (const monthKey of logMonthKeys) {
+    const logs = readLogs(monthKey);
+
+    const anchor = logs
+      .map((log) => parseLogDate(log.date)?.startOf('day'))
+      .filter((d): d is dayjs.Dayjs => !!d?.isValid() && d.isBefore(today) && d.day() !== 0 && d.day() !== 6)
+      .sort((a, b) => b.valueOf() - a.valueOf())[0];
+
+    if (anchor) return collectLogsFromDate(anchor, today);
+  }
+
+  return [];
 }
 
 async function callStandupApi(today: string): Promise<string | null> {
@@ -125,7 +127,6 @@ async function callStandupApi(today: string): Promise<string | null> {
   const response = await httpClient.post<{ markdown: string }>('/api/standup', { entries, today }, { headers });
 
   localStorage.setItem(storageKeys.catchUp.summary(today), response.data.markdown);
-  localStorage.setItem(storageKeys.catchUp.lastFetchedAt, new Date().toISOString());
 
   return response.data.markdown;
 }


### PR DESCRIPTION
…weekend group

- Replace lastFetchedAt-based range with a scan of all stored log months, anchoring to the most recent weekday with logs before today. Fixes the first-day-of-month gap where lastFetchedAt pointed to a log-free weekend.
- Remove catchUpLastFetchedAt storage key — no longer written or read.
- Update standup prompt to put Saturday/Sunday entries in a ## Weekend group.
- Reduce release notification auto-dismiss from 10 s to 5 s.