### PR TITLE
feat(logs): add plan entry type with optional duration

### DIFF
--- a/api/standup.ts
+++ b/api/standup.ts
@@ -17,44 +17,90 @@ interface RequestItem {
   logs: RequestLog[];
 }
 
+interface RequestPlanTask {
+  task: string;
+  description?: string;
+}
+
+interface RequestPlan {
+  id: string;
+  project: string;
+  tasks: RequestPlanTask[];
+}
+
 interface StandupRequest {
   items: RequestItem[];
+  plans?: RequestPlan[];
   today: string;
 }
 
-function buildPrompt(items: RequestItem[], today: string): string {
-  const itemsText = items
-    .map(
-      (it) =>
-        `id: ${it.id}\nproject: ${it.project}\n${it.logs
-          .map((l) => `  - ${l.task}${l.description ? `: ${l.description}` : ''} (${l.duration})`)
-          .join('\n')}`,
-    )
-    .join('\n\n');
+function buildPrompt(items: RequestItem[], today: string, plans?: RequestPlan[]): string {
+  const hasDid = items.length > 0;
+  const hasTodo = plans && plans.length > 0;
 
-  return `You are helping a developer recap recent work for a standup. Today is ${today}.
-Each block below is one project the developer worked on. "id" is a reference key, "project" is the display label. The indented sub-lines are tasks/notes done under it.
+  const didSection = hasDid
+    ? items
+        .map(
+          (it) =>
+            `id: ${it.id}\nproject: ${it.project}\n${it.logs
+              .map((l) => `  - ${l.task}${l.description ? `: ${l.description}` : ''} (${l.duration})`)
+              .join('\n')}`,
+        )
+        .join('\n\n')
+    : '';
 
-${itemsText}
+  const todoSection = hasTodo
+    ? plans!
+        .map(
+          (p) =>
+            `id: ${p.id}\nproject: ${p.project}\n${p.tasks
+              .map((t) => `  - ${t.task}${t.description ? `: ${t.description}` : ''}`)
+              .join('\n')}`,
+        )
+        .join('\n\n')
+    : '';
 
-For each block, write ONE concise past-tense sentence describing what was done, merging the sub-lines.
+  const didInstruction = hasDid
+    ? `For each Did block, write ONE concise past-tense sentence describing what was done, merging the sub-lines.
 Start the sentence with the "project" value exactly as given — do not include the "id" value in the sentence text.
+Return these in "lines".`
+    : '';
+
+  const todoInstruction = hasTodo
+    ? `For each Todo block, write ONE concise present/future-tense sentence describing what will be done today.
+Start the sentence with the "project" value exactly as given — do not include the "id" value in the sentence text.
+Return these in "todoLines".`
+    : '';
+
+  const responseShape = hasTodo
+    ? '{"lines":[{"id":"<id>","text":"<sentence>"}],"todoLines":[{"id":"<id>","text":"<sentence>"}]}'
+    : '{"lines":[{"id":"<id>","text":"<sentence>"}]}';
+
+  return `You are helping a developer write a standup update. Today is ${today}.
+${hasDid ? `\nDid (recent work):\n${didSection}` : ''}
+${hasTodo ? `\nTodo (plans for today):\n${todoSection}` : ''}
+
+${didInstruction}
+${todoInstruction}
 Return STRICT JSON only — no markdown, no code fences, no extra prose:
-{"lines":[{"id":"<id>","text":"<sentence>"}]}
-with exactly one entry per block, echoing each block's "id" value unchanged.`;
+${responseShape}
+with exactly one entry per block in each array, echoing each block's "id" value unchanged.`;
 }
 
-function parseLines(raw: string): { id: string; text: string }[] {
+function parseResponse(raw: string): { lines: { id: string; text: string }[]; todoLines: { id: string; text: string }[] } {
   const cleaned = raw
     .trim()
     .replace(/^```(?:json)?/i, '')
     .replace(/```$/, '')
     .trim();
   try {
-    const parsed = JSON.parse(cleaned) as { lines?: { id: string; text: string }[] };
-    return Array.isArray(parsed.lines) ? parsed.lines : [];
+    const parsed = JSON.parse(cleaned) as { lines?: { id: string; text: string }[]; todoLines?: { id: string; text: string }[] };
+    return {
+      lines: Array.isArray(parsed.lines) ? parsed.lines : [],
+      todoLines: Array.isArray(parsed.todoLines) ? parsed.todoLines : [],
+    };
   } catch {
-    return [];
+    return { lines: [], todoLines: [] };
   }
 }
 
@@ -82,10 +128,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const { text } = await generateText({
       model: requireAiModel(),
-      prompt: buildPrompt(body.items, body.today),
+      prompt: buildPrompt(body.items, body.today, body.plans),
     });
 
-    return res.json({ lines: parseLines(text) });
+    return res.json(parseResponse(text));
   } catch (err) {
     if (err instanceof AuthError) {
       return res.status(err.status).json({ error: err.message });

--- a/e2e/interfaces/taskEntry.ts
+++ b/e2e/interfaces/taskEntry.ts
@@ -3,7 +3,8 @@
   date: Date;
   project: string;
   task: string;
-  duration: number;
+  duration: number | undefined;
   description?: string;
   isLogged?: boolean;
+  type?: 'log' | 'plan';
 }

--- a/e2e/logHelpers/fileHelper.ts
+++ b/e2e/logHelpers/fileHelper.ts
@@ -21,7 +21,7 @@ function getTaskEntries(filePath: string): TaskEntry[] {
     },
     transform: (value, field) => {
       if (field === 'date') return new Date(value);
-      if (field === 'duration') return parseInt(value, 10);
+      if (field === 'duration') return value ? parseInt(value, 10) : undefined;
       if (field === 'isLogged') return value.toLowerCase() === 'true';
       return value;
     },
@@ -30,7 +30,7 @@ function getTaskEntries(filePath: string): TaskEntry[] {
     },
   });
 
-  return (result.data as TaskEntry[]).filter((entry) => !entry.isLogged);
+  return (result.data as TaskEntry[]).filter((entry) => !entry.isLogged && entry.type !== 'plan');
 }
 
 /**
@@ -47,7 +47,7 @@ function getAllTaskEntries(filePath: string): TaskEntry[] {
     },
     transform: (value, field) => {
       if (field === 'date') return new Date(value);
-      if (field === 'duration') return parseInt(value, 10);
+      if (field === 'duration') return value ? parseInt(value, 10) : undefined;
       if (field === 'isLogged') return value.toLowerCase() === 'true';
       return value;
     },
@@ -81,7 +81,8 @@ function saveTaskEntriesWithLoggedStatus(filePath: string, processedEntries: Tas
       Date: dayjs(entry.date).format('MM-DD-YY'),
       Project: entry.project,
       Task: entry.task,
-      Duration: entry.duration,
+      Duration: entry.duration ?? '',
+      Type: entry.type ?? 'log',
       Description: entry.description || '',
       // Update isLogged status if this entry was processed, otherwise keep original
       IsLogged: processedEntry ? (processedEntry.isLogged ? 'true' : 'false') : (entry.isLogged ? 'true' : 'false'),

--- a/e2e/xeroWorkLogger.spec.ts
+++ b/e2e/xeroWorkLogger.spec.ts
@@ -51,10 +51,11 @@ test.describe('Xero Work Logger', () => {
           await createTask(page, taskName);
 
           for (const entry of tasks) {
-            await addTimeSpentToTask(page, entry.task, entry.duration, entry.date, entry.description);
+            // Plan entries are filtered out by getTaskEntries before reaching here
+            await addTimeSpentToTask(page, entry.task, entry.duration!, entry.date, entry.description);
             entry.isLogged = true;
             const label = progress.increment();
-            const duration = convertMinutesToHourMinutes(entry.duration);
+            const duration = convertMinutesToHourMinutes(entry.duration!);
             const date = dayjs(entry.date).format('YYYY-MM-DD');
             const desc = entry.description ? ` · "${entry.description}"` : '';
             console.log(`    ${label} ⏱  ${date} · ${duration}${desc}`);

--- a/src/components/AiChatMessage.vue
+++ b/src/components/AiChatMessage.vue
@@ -31,6 +31,9 @@ const tool = computed(() => props.message.metadata?.tool);
 const extractedLogs = computed(() => props.message.metadata?.extractedLogs);
 const saveState = computed(() => props.message.metadata?.saveState);
 const catchUpItems = computed<CatchUpRenderItem[] | undefined>(() => props.message.metadata?.catchUpItems);
+const catchUpHasGroups = computed(() => catchUpItems.value?.some((i) => i.group) ?? false);
+const catchUpDidItems = computed(() => catchUpItems.value?.filter((i) => i.group === 'did') ?? []);
+const catchUpTodoItems = computed(() => catchUpItems.value?.filter((i) => i.group === 'todo') ?? []);
 
 const handleSave = () => {
   if (extractedLogs.value?.length) {
@@ -130,17 +133,42 @@ const copyMessage = () => {
         </p>
 
         <!-- catchUp tool result -->
-        <ul v-if="tool === 'catchUp' && catchUpItems?.length" class="catchup-list">
-          <li
-            v-for="(entry, idx) in catchUpItems"
-            :key="idx"
-            class="catchup-item"
-            :class="{ 'is-ongoing': entry.ongoing }"
-          >
-            {{ entry.text
-            }}<span v-if="entry.effortLabel" class="catchup-effort"> · {{ entry.effortLabel }}</span>
-          </li>
-        </ul>
+        <template v-if="tool === 'catchUp' && catchUpItems?.length">
+          <!-- Grouped: Did / Todo sections -->
+          <template v-if="catchUpHasGroups">
+            <p class="catchup-group-header">Did</p>
+            <ul class="catchup-list">
+              <li
+                v-for="(entry, idx) in catchUpDidItems"
+                :key="idx"
+                class="catchup-item"
+                :class="{ 'is-ongoing': entry.ongoing }"
+              >
+                {{ entry.text
+                }}<span v-if="entry.effortLabel" class="catchup-effort"> · {{ entry.effortLabel }}</span>
+              </li>
+            </ul>
+            <p class="catchup-group-header mt-2">Todo</p>
+            <ul class="catchup-list">
+              <li v-for="(entry, idx) in catchUpTodoItems" :key="idx" class="catchup-item">
+                {{ entry.text }}
+              </li>
+            </ul>
+          </template>
+
+          <!-- No groups: existing flat list -->
+          <ul v-else class="catchup-list">
+            <li
+              v-for="(entry, idx) in catchUpItems"
+              :key="idx"
+              class="catchup-item"
+              :class="{ 'is-ongoing': entry.ongoing }"
+            >
+              {{ entry.text
+              }}<span v-if="entry.effortLabel" class="catchup-effort"> · {{ entry.effortLabel }}</span>
+            </li>
+          </ul>
+        </template>
 
         <!-- extractLogs tool result + action area -->
         <template v-if="tool === 'extractLogs' && extractedLogs?.length">
@@ -214,5 +242,14 @@ const copyMessage = () => {
 .catchup-effort {
   color: rgba(140, 140, 140, 0.85);
   font-variant-numeric: tabular-nums;
+}
+
+.catchup-group-header {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(140, 140, 140, 0.85);
+  margin: 4px 0 2px;
 }
 </style>

--- a/src/components/BulkLogForm.vue
+++ b/src/components/BulkLogForm.vue
@@ -81,7 +81,7 @@ const validationSchema = object({
   selectedDates: array(date()).min(1, 'At least one date must be selected'),
   project: string().required('Required'),
   task: string().required('Required'),
-  duration: number().required('Required').min(1, 'Must be greater than 0'),
+  duration: number().optional().test('min-if-set', 'Must be greater than 0', (v) => !v || v >= 1),
   description: string(),
   categoryName: string().typeError('Please enter a category name').optional(),
 });
@@ -127,6 +127,9 @@ const scrollToFirstError = async () => {
 };
 
 const onSave = handleSubmit((values) => {
+  const duration = values.duration ? Math.round(values.duration) : undefined;
+  const type: 'log' | 'plan' = duration ? 'log' : 'plan';
+
   // Edit mode: Update single log (emit as array with 1 item)
   if (isEditMode.value && editingLog) {
     const updatedLog: TimeLog = {
@@ -134,7 +137,8 @@ const onSave = handleSubmit((values) => {
       date: dayjs(values.selectedDates[0]).format(shortDateFormat),
       project: values.project!,
       task: values.task!,
-      duration: Math.round(values.duration!),
+      duration,
+      type,
       description: values.description,
     };
 
@@ -146,7 +150,8 @@ const onSave = handleSubmit((values) => {
       date: dayjs(date).format(shortDateFormat),
       project: values.project!,
       task: values.task!,
-      duration: Math.round(values.duration!),
+      duration,
+      type,
       description: values.description,
     }));
 
@@ -216,6 +221,11 @@ const onCategoryUpdate = (v: unknown) => {
   const name = v == null ? '' : typeof v === 'object' ? (v as { name: string }).name : (v as string);
   categoryNameField.setValue(name);
 };
+
+const durationHint = computed(() => {
+  const val = durationField.value.value;
+  return val ? minutesToHourWithMinutes(val) : 'Leave empty to save as plan';
+});
 
 const onHourClick = (hour: number) => {
   // Add to the existing duration instead of replacing it
@@ -370,7 +380,7 @@ watch(
         :error-messages="errors.duration"
         :min="0"
         :step="30"
-        :hint="minutesToHourWithMinutes(durationField.value.value)"
+        :hint="durationHint"
         persistent-hint
       />
 

--- a/src/components/InsightsPanel.vue
+++ b/src/components/InsightsPanel.vue
@@ -131,7 +131,7 @@ const allProjectsSorted = computed((): ProjectBreakdownItem[] => {
 
   const grouped: Record<string, number> = {};
   for (const log of props.timeLogs) {
-    grouped[log.project] = (grouped[log.project] ?? 0) + log.duration;
+    grouped[log.project] = (grouped[log.project] ?? 0) + (log.duration ?? 0);
   }
 
   return Object.entries(grouped)

--- a/src/components/LogList.vue
+++ b/src/components/LogList.vue
@@ -109,7 +109,7 @@ const loggedTimeByDates = computed(() =>
     .groupBy((item) => item.date)
     .map((items, date) => ({
       date,
-      durationSum: sumBy(items, 'duration'),
+      durationSum: sumBy(items, (item) => item.duration ?? 0),
       tasks: items,
     }))
     .orderBy((item) => item.date)
@@ -248,7 +248,8 @@ const readCsv = (file?: File) => {
             <VCard class="elevation-0 rounded-lg">
               <VDataTable :items="group.tasks" :headers="headers" class="bg-container" hide-default-footer>
                 <template #item.duration="{ item }">
-                  {{ minutesToHourWithMinutes(item.duration) }}
+                  <VChip v-if="item.type === 'plan'" color="success" size="x-small" variant="tonal">Plan</VChip>
+                  <span v-else>{{ minutesToHourWithMinutes(item.duration ?? 0) }}</span>
                 </template>
 
                 <!--suppress VueUnrecognizedSlot -->

--- a/src/components/WorkTimeBarChart.vue
+++ b/src/components/WorkTimeBarChart.vue
@@ -75,7 +75,7 @@ const weekStartDate = computed(() => {
 });
 
 const todayMinutes = computed(() =>
-  timeLogs.value.filter((log) => log.date === todayStr.value).reduce((sum, log) => sum + log.duration, 0),
+  timeLogs.value.filter((log) => log.date === todayStr.value).reduce((sum, log) => sum + (log.duration ?? 0), 0),
 );
 
 const thisWeekMinutes = computed(() => {
@@ -85,7 +85,7 @@ const thisWeekMinutes = computed(() => {
       const d = dayjs(log.date, shortDateFormat);
       return d.isValid() && !d.isBefore(weekStart) && !d.isAfter(dayjs().endOf('day'));
     })
-    .reduce((sum, log) => sum + log.duration, 0);
+    .reduce((sum, log) => sum + (log.duration ?? 0), 0);
 });
 
 // Chart data computed property (automatically reactive to props and storage changes)
@@ -105,7 +105,7 @@ const chartData = computed(() => {
         data: daysInMonth.value.map((d) =>
           chain(logsByProject)
             .filter((item) => item.date === d.format(shortDateFormat))
-            .map((item) => round(item.duration / 60, 1))
+            .map((item) => round((item.duration ?? 0) / 60, 1))
             .sum()
             .value(),
         ),
@@ -130,7 +130,7 @@ const chartData = computed(() => {
         data: daysInMonth.value.map((d) =>
           chain(logsByProject)
             .filter((item) => item.date === d.format(shortDateFormat))
-            .map((item) => round(item.duration / 60, 1))
+            .map((item) => round((item.duration ?? 0) / 60, 1))
             .sum()
             .value(),
         ),
@@ -144,7 +144,7 @@ const chartData = computed(() => {
       const totalLogged = chain(timeLogs.value)
         .filter((log) => log.date === d.format(shortDateFormat))
         .filter((log) => !settingsStore.weekendDays.includes(dayjs(log.date, shortDateFormat).day()))
-        .map((log) => round(log.duration / 60, 1))
+        .map((log) => round((log.duration ?? 0) / 60, 1))
         .sum()
         .value();
 

--- a/src/composables/useAiChat.ts
+++ b/src/composables/useAiChat.ts
@@ -137,9 +137,16 @@ export function useAiChat() {
   const injectCatchUp = (items: CatchUpRenderItem[]) => {
     const id = `catchup-${Date.now()}`;
     // Plain-text bullet list for AI conversation context (follow-up questions)
-    const text = items
-      .map((i) => `• ${i.text}${i.effortLabel ? ` · ${i.effortLabel}` : ''}`)
-      .join('\n');
+    const hasGroups = items.some((i) => i.group);
+    const text = hasGroups
+      ? [
+          'Did:',
+          ...items.filter((i) => i.group === 'did').map((i) => `• ${i.text}${i.effortLabel ? ` · ${i.effortLabel}` : ''}`),
+          '',
+          'Todo:',
+          ...items.filter((i) => i.group === 'todo').map((i) => `• ${i.text}`),
+        ].join('\n')
+      : items.map((i) => `• ${i.text}${i.effortLabel ? ` · ${i.effortLabel}` : ''}`).join('\n');
 
     const syntheticMsg = {
       id,

--- a/src/composables/useCatchUpSummary.ts
+++ b/src/composables/useCatchUpSummary.ts
@@ -62,6 +62,12 @@ export interface CatchUpItem {
   ongoing: boolean;
 }
 
+interface RequestPlan {
+  id: string;
+  project: string;
+  tasks: { task: string; description?: string }[];
+}
+
 export type { CatchUpRenderItem };
 
 // ── Notification → Chat bridge (module-level singleton, no reactive signal) ──
@@ -90,13 +96,13 @@ export function buildCatchUpItems(didLogs: TimeLog[], accumulated: Map<string, n
   }
 
   const ranked = Array.from(byProject.entries()).map(([project, logs]) => {
-    const windowMinutes = logs.reduce((sum, l) => sum + l.duration, 0);
+    const windowMinutes = logs.reduce((sum, l) => sum + (l.duration ?? 0), 0);
     const accumulatedMinutes = accumulated.get(project) ?? windowMinutes;
     const latest = logs.reduce((max, l) => (l.date > max ? l.date : max), '');
     const item: CatchUpItem = {
       id: deriveItemId(project),
       project,
-      logs: logs.map((l) => ({ task: l.task, description: l.description, duration: l.duration })),
+      logs: logs.map((l) => ({ task: l.task, description: l.description, duration: l.duration ?? 0 })),
       windowMinutes,
       accumulatedMinutes,
       ongoing: accumulatedMinutes >= LONG_RUNNING_THRESHOLD_MINUTES,
@@ -118,7 +124,7 @@ export function buildCatchUpItems(didLogs: TimeLog[], accumulated: Map<string, n
 export function accumulateMinutesByProject(logs: TimeLog[]): Map<string, number> {
   const totals = new Map<string, number>();
   for (const log of logs) {
-    totals.set(log.project, (totals.get(log.project) ?? 0) + log.duration);
+    totals.set(log.project, (totals.get(log.project) ?? 0) + (log.duration ?? 0));
   }
   return totals;
 }
@@ -207,6 +213,7 @@ function getLogsForSummary(): TimeLog[] {
     const logs = readLogs(monthKey);
 
     const anchor = logs
+      .filter((log) => log.type !== 'plan')
       .map((log) => parseLogDate(log.date)?.startOf('day'))
       .filter((d): d is dayjs.Dayjs => !!d?.isValid() && d.isBefore(today) && d.day() !== 0 && d.day() !== 6)
       .sort((a, b) => b.valueOf() - a.valueOf())[0];
@@ -247,13 +254,41 @@ function setCachedSummary(items: CatchUpRenderItem[]): void {
   localStorage.setItem(storageKeys.catchUp.summaries, JSON.stringify({ key, items } satisfies SummaryCache));
 }
 
-async function callStandupApi(today: string): Promise<CatchUpRenderItem[] | null> {
-  const didLogs = getLogsForSummary();
-  if (!didLogs.length) return null;
+function getTodayPlans(today: dayjs.Dayjs): TimeLog[] {
+  const monthKey = `timeLogs-${today.format(yearAndMonthFormat)}`;
+  return readLogs(monthKey).filter((log) => {
+    const logDate = parseLogDate(log.date)?.startOf('day');
+    return logDate?.isSame(today, 'day') && log.type === 'plan';
+  });
+}
 
-  const accumulated = accumulateMinutesByProject(collectAccumulationLogs(dayjs(today).startOf('day')));
+function buildPlanRequestItems(plans: TimeLog[]): RequestPlan[] {
+  const byProject = new Map<string, TimeLog[]>();
+  for (const plan of plans) {
+    if (!byProject.has(plan.project)) byProject.set(plan.project, []);
+    byProject.get(plan.project)!.push(plan);
+  }
+  return Array.from(byProject.entries()).map(([project, logs]) => ({
+    id: `plan-${deriveItemId(project)}`,
+    project,
+    tasks: logs.map((l) => ({ task: l.task, description: l.description })),
+  }));
+}
+
+async function callStandupApi(today: string): Promise<CatchUpRenderItem[] | null> {
+  const todayDayjs = dayjs(today).startOf('day');
+
+  // Separate did logs (actual work) from plan entries
+  const allLogs = getLogsForSummary();
+  const didLogs = allLogs.filter((l) => l.type !== 'plan');
+
+  const todayPlans = getTodayPlans(todayDayjs);
+  const hasTodayPlans = todayPlans.length > 0;
+
+  if (!didLogs.length && !hasTodayPlans) return null;
+
+  const accumulated = accumulateMinutesByProject(collectAccumulationLogs(todayDayjs).filter((l) => l.type !== 'plan'));
   const items = buildCatchUpItems(didLogs, accumulated);
-  if (!items.length) return null;
 
   const requestItems = items.map((item) => ({
     id: item.id,
@@ -265,16 +300,30 @@ async function callStandupApi(today: string): Promise<CatchUpRenderItem[] | null
     })),
   }));
 
+  const planItems = hasTodayPlans ? buildPlanRequestItems(todayPlans) : [];
+  const planIdToProject = new Map(planItems.map((p) => [p.id, p.project]));
+
   const headers = await buildAuthHeaders();
-  const response = await httpClient.post<{ lines: { id: string; text: string }[] }>(
+  const response = await httpClient.post<{ lines: { id: string; text: string }[]; todoLines?: { id: string; text: string }[] }>(
     '/api/standup',
-    { items: requestItems, today },
+    { items: requestItems, plans: planItems, today },
     { headers },
   );
 
-  const rendered = applyLines(items, response.data.lines ?? []);
+  const didRendered = applyLines(items, response.data.lines ?? []);
+  const todoRendered: CatchUpRenderItem[] = (response.data.todoLines ?? []).map((l) => ({
+    project: planIdToProject.get(l.id) ?? l.id,
+    text: l.text,
+    ongoing: false,
+    group: 'todo' as const,
+  }));
+
+  const rendered: CatchUpRenderItem[] = hasTodayPlans
+    ? [...didRendered.map((r) => ({ ...r, group: 'did' as const })), ...todoRendered]
+    : didRendered;
+
   setCachedSummary(rendered);
-  return rendered;
+  return rendered.length ? rendered : null;
 }
 
 export async function fetchCatchUpItems(): Promise<CatchUpRenderItem[] | null> {

--- a/src/interfaces/AiChat.ts
+++ b/src/interfaces/AiChat.ts
@@ -6,7 +6,7 @@ export interface ExtractedLog {
   project: string;
   task: string;
   date: string; // 'YYYY-MM-DD'
-  duration: number; // minutes
+  duration?: number; // minutes; undefined = plan entry
   description?: string;
 }
 

--- a/src/interfaces/CatchUp.ts
+++ b/src/interfaces/CatchUp.ts
@@ -3,4 +3,5 @@ export interface CatchUpRenderItem {
   text: string;
   ongoing: boolean;
   effortLabel?: string;
+  group?: 'did' | 'todo';
 }

--- a/src/interfaces/TimeLog.ts
+++ b/src/interfaces/TimeLog.ts
@@ -3,6 +3,7 @@ export interface TimeLog {
   date: string; // 'YYYY-MM-DD'
   project: string;
   task: string;
-  duration: number;
+  duration?: number; // undefined = plan entry
+  type: 'log' | 'plan';
   description?: string;
 }

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -187,7 +187,8 @@ const exportToCsv = () => {
     Date: dayjs(log.date).format(templateDateFormat),
     Project: log.project,
     Task: log.task,
-    Duration: log.duration,
+    Duration: log.duration ?? '',
+    Type: log.type ?? 'log',
     Description: log.description,
     IsLogged: false,
   }));
@@ -209,9 +210,10 @@ const importCsv = async (file?: File) => {
     transformHeader(header: string): string {
       return camelCase(header);
     },
-    transform(value: string, header: string): string | number {
+    transform(value: string, header: string): string | number | undefined {
       if (header === 'date') return dayjs(value, templateDateFormat).format(shortDateFormat);
-      if (header === 'duration') return toNumber(value);
+      if (header === 'duration') return value ? toNumber(value) : undefined;
+      if (header === 'type') return value === 'plan' ? 'plan' : 'log';
 
       return value;
     },
@@ -229,14 +231,16 @@ const importCsv = async (file?: File) => {
   }
 
   const dataWithIds: TimeLog[] = result.data.map((item) => {
-    const log = item as Record<string, string | number>;
+    const log = item as Record<string, string | number | undefined>;
+    const duration = log.duration as number | undefined;
     return {
       id: (log.id as string) ?? nanoid(),
       date: log.date as string,
       project: log.project as string,
       task: log.task as string,
-      duration: log.duration as number,
-      description: log.description as string,
+      duration: duration || undefined,
+      type: (log.type as 'log' | 'plan' | undefined) ?? (duration ? 'log' : 'plan'),
+      description: log.description as string | undefined,
     };
   });
 
@@ -277,12 +281,14 @@ const onAiSaveLogs = (extractedLogs: ExtractedLog[]) => {
     const logMonth = dayjs(log.date, 'YYYY-MM-DD').month() + 1; // 1-based month number
     const id = nanoid();
     const monthStorage = getTimeLogsForMonth(logMonth);
+    const duration = log.duration;
     monthStorage.value.push({
       id,
       date,
       project: log.project,
       task: log.task,
-      duration: log.duration,
+      duration,
+      type: duration ? 'log' : 'plan',
       description: log.description,
     });
     savedBatch.push({ id, month: logMonth });


### PR DESCRIPTION
Introduces a first-class plan concept: TimeLog gains a required `type: 'log' | 'plan'` field and `duration` becomes optional (undefined signals a plan entry). Type is auto-inferred on save — leaving Duration empty creates a plan.

- BulkLogForm: duration optional, hint switches to "Leave empty to save as plan", type derived on save
- LogList: Plan chip in duration cell (keyed on item.type)
- WorkTimeBarChart / InsightsPanel: guard duration ?? 0 for plan rows
- CSV export: adds Type column, Duration empty for plans
- CSV import: sanitises type field, parses empty duration as undefined
- AI save path: derives type from duration presence
- Xero automation: filters plan rows before submission, preserves Type column through CSV round-trips
- Standup API: accepts optional plans[], returns todoLines[] alongside lines[]; prompt updated for Did/Todo sections
- CatchUp: separates did logs from plans, passes today's plans to AI, renders Did/Todo groups in AiChatMessage when plans exist